### PR TITLE
Reenable E402 and support for multiple paths

### DIFF
--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -95,19 +95,22 @@ def set_arguments(parser):
     plint = parser.add_parser('lint', help='check code with pylint')
     plint.add_argument('path', type=str,
                        help='Path to check (empty for full tree check)',
-                       nargs='?',
-                       default="")
+                       nargs='*',
+                       default=None)
     plint.set_defaults(func=run_lint)
 
 
 def run_lint(args):
-    path = args.path
-    if not path:
-        path = os.getcwd()
+    paths = args.path
+    if not paths:
+        paths = [os.getcwd()]
 
     linter = Linter(verbose=args.verbose)
 
-    if linter.check(path):
+    status = True
+    for path in paths:
+        status &= linter.check(path)
+    if status:
         log.info("Syntax check PASS")
         return 0
     else:

--- a/inspektor/reindent.py
+++ b/inspektor/reindent.py
@@ -239,19 +239,22 @@ def set_arguments(parser):
     pindent = parser.add_parser('indent', help='check code indentation')
     pindent.add_argument('path', type=str,
                          help='Path to check (empty for full tree check)',
-                         nargs='?',
-                         default="")
+                         nargs='*',
+                         default=None)
     pindent.set_defaults(func=run_reindent)
 
 
 def run_reindent(args):
-    path = args.path
-    if not path:
-        path = os.getcwd()
+    paths = args.path
+    if not paths:
+        paths = [os.getcwd()]
 
     reindenter = Reindenter(verbose=args.verbose)
 
-    if reindenter.check(path):
+    status = True
+    for path in paths:
+        status &= reindenter.check(path)
+    if status:
         log.info("Indentation check PASS")
         return 0
     else:

--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -91,19 +91,22 @@ def set_arguments(parser):
                                help='check code compliance to PEP8')
     pstyle.add_argument('path', type=str,
                         help='Path to check (empty for full tree check)',
-                        nargs='?',
-                        default="")
+                        nargs='*',
+                        default=None)
     pstyle.set_defaults(func=run_style)
 
 
 def run_style(args):
-    path = args.path
-    if not path:
-        path = os.getcwd()
+    paths = args.path
+    if not paths:
+        paths = [os.getcwd()]
 
     style_checker = StyleChecker(verbose=args.verbose)
 
-    if style_checker.check(path):
+    status = True
+    for path in paths:
+        status &= style_checker.check(path)
+    if status:
         log.info("PEP8 compliance check PASS")
         return 0
     else:


### PR DESCRIPTION
Hi @lmr,

I looked again at the E402 problem and the latest PEP8 update fixes the issue with E402 being incorrectly detect by PEP8 when used as module. I think we should re-enable it again (there are couple of nasty modules in avocado, thought, but no false-positives).

The second commit is because I had my `git rerere` poisoned by inspektor. It's really better to use `git ls-files` and check only the ones which are in this repository, rather than full recursive check.

Kind reagards,
Lukáš