### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/inspektor.spec
+++ b/inspektor.spec
@@ -2,7 +2,7 @@
 Summary: Inspektor python project checker
 Name: inspektor
 Version: %{inspektorversion}
-Release: 5%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: https://github.com/autotest/inspektor

--- a/inspektor.spec
+++ b/inspektor.spec
@@ -2,7 +2,7 @@
 Summary: Inspektor python project checker
 Name: inspektor
 Version: %{inspektorversion}
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: https://github.com/autotest/inspektor
@@ -40,6 +40,10 @@ patch review for programs developed by the autotest project team.
 
 
 %changelog
+* Wed Mar 11 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.1.15-2
+- Fix build on COPR
+* Wed Mar 11 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.1.15-1
+- New upstream version 0.1.15
 * Tue Apr 29 2014 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.1.9-5
 - Moved macro definitions to rpm spec file, fix build on COPR
 * Tue Apr 29 2014 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.1.9-4

--- a/inspektor.spec
+++ b/inspektor.spec
@@ -1,4 +1,4 @@
-%global inspektorversion %(%{getenv:PWD}/inspektor/version.py)
+%global inspektorversion 0.1.15
 Summary: Inspektor python project checker
 Name: inspektor
 Version: %{inspektorversion}

--- a/inspektor/__init__.py
+++ b/inspektor/__init__.py
@@ -85,4 +85,12 @@ DEFAULT_LOGGING = {
 }
 
 
-logging.config.dictConfig(DEFAULT_LOGGING)
+from logging import config
+
+if not hasattr(config, 'dictConfig'):
+    from logutils import dictconfig
+    cfg_func = dictconfig.dictConfig
+else:
+    cfg_func = config.dictConfig
+
+cfg_func(DEFAULT_LOGGING)

--- a/inspektor/license.py
+++ b/inspektor/license.py
@@ -85,7 +85,7 @@ class LicenseChecker(object):
             if first_line is not None:
                 content = content[1:]
             content = "".join(content)
-            if not self.base_license_contents in content:
+            if self.base_license_contents not in content:
                 new_content = ""
                 if first_line is not None:
                     new_content += first_line

--- a/inspektor/version.py
+++ b/inspektor/version.py
@@ -19,7 +19,7 @@ __all__ = ['MAJOR', 'MINOR', 'RELEASE', 'VERSION']
 
 MAJOR = 0
 MINOR = 1
-RELEASE = 14
+RELEASE = 15
 
 VERSION = "%s.%s.%s" % (MAJOR, MINOR, RELEASE)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from distutils.core import setup
 
 setup(name='inspektor',
-      version='0.1.14',
+      version='0.1.15',
       description='Inspektor code checker',
       author='Lucas Meneghel Rodrigues',
       author_email='lmr@redhat.com',


### PR DESCRIPTION
Make inspektor compatible with python 2.6 and RHEL 6.