### PR TITLE
Ignore filenames not related to source code.

### DIFF
--- a/inspektor/inspector.py
+++ b/inspektor/inspector.py
@@ -17,6 +17,7 @@ import stat
 
 PY_EXTENSIONS = ['.py']
 SHEBANG = '#!'
+IGNORE_PREFIX = ('~', '#', '.swp', '.pyc', '.pyo', '.o')
 
 
 class PathInspector(object):

--- a/inspektor/license.py
+++ b/inspektor/license.py
@@ -15,6 +15,7 @@
 import logging
 import os
 from inspector import PathInspector
+from inspector import IGNORE_PREFIX
 
 log = logging.getLogger("inspektor.license")
 
@@ -64,6 +65,9 @@ class LicenseChecker(object):
     def check_dir(self, path):
         def visit(arg, dirname, filenames):
             for filename in filenames:
+                if filename.endswith(IGNORE_PREFIX):
+                    log.debug("Ignoring '%s' due filename prefix", filename)
+                    continue
                 self.check_file(os.path.join(dirname, filename))
 
         os.path.walk(path, visit, None)

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -19,6 +19,7 @@ import sys
 from pylint.lint import Run
 
 from inspector import PathInspector
+from inspector import IGNORE_PREFIX
 
 log = logging.getLogger("inspektor.lint")
 
@@ -55,6 +56,9 @@ class Linter(object):
         """
         def visit(arg, dirname, filenames):
             for filename in filenames:
+                if filename.endswith(IGNORE_PREFIX):
+                    log.debug("Ignoring '%s' due filename prefix", filename)
+                    continue
                 self.check_file(os.path.join(dirname, filename))
 
         os.path.walk(path, visit, None)

--- a/inspektor/reindent.py
+++ b/inspektor/reindent.py
@@ -17,6 +17,7 @@ import tokenize
 import logging
 
 from inspector import PathInspector
+from inspector import IGNORE_PREFIX
 
 log = logging.getLogger("inspektor.reindent")
 
@@ -222,6 +223,10 @@ class Reindenter(object):
 
     def check_dir(self, path):
         def visit(arg, dirname, filenames):
+            for filename in filenames:
+                if filename.endswith(IGNORE_PREFIX):
+                    log.debug("Ignoring '%s' due filename prefix", filename)
+                    continue
             for filename in filenames:
                 self.check_file(os.path.join(dirname, filename))
 

--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -25,6 +25,7 @@ except ImportError:
     AUTOPEP8_CAPABLE = False
 
 from inspector import PathInspector
+from inspector import IGNORE_PREFIX
 
 log = logging.getLogger("inspektor.style")
 
@@ -48,6 +49,10 @@ class StyleChecker(object):
         :param path: Path to a directory.
         """
         def visit(arg, dirname, filenames):
+            for filename in filenames:
+                if filename.endswith(IGNORE_PREFIX):
+                    log.debug("Ignoring '%s' due filename prefix", filename)
+                    continue
             for filename in filenames:
                 self.check_file(os.path.join(dirname, filename))
 


### PR DESCRIPTION
When walking from a directory, ignore filenames that ends with: `~ # .swp .pyc .pyo .o` since they are not related to source code.