### PR TITLE
Ignore filenames which are not the proper source code [V2]

### DIFF
--- a/inspektor/inspector.py
+++ b/inspektor/inspector.py
@@ -14,6 +14,7 @@
 
 import os
 import stat
+import fnmatch
 
 PY_EXTENSIONS = ['.py']
 SHEBANG = '#!'
@@ -23,6 +24,20 @@ class PathInspector(object):
 
     def __init__(self, path):
         self.path = path
+        self.ignore = ('*~', '*#', '*.swp', '*.py?', '*.o')
+        self._read_gitignore()
+
+    def _read_gitignore(self):
+        config_ignore = '{home}/.config/git/ignore'.format(
+            home=os.environ.get('HOME'))
+        git_dir_ignore = '{gitdir}/.config/git/ignore'.format(
+            gitdir=os.environ.get('GIT_DIR'))
+        dot_ignore = '.gitignore'
+        for ign in (dot_ignore, git_dir_ignore, config_ignore):
+            if os.path.isfile(ign):
+                with open(ign) as f:
+                    self.ignore = [x.strip() for x in f.readlines()]
+                break
 
     def get_first_line(self):
         first_line = ""
@@ -56,3 +71,11 @@ class PathInspector(object):
                 return True
 
         return self.is_script(language='python')
+
+    def is_toignore(self):
+        for pat in self.ignore:
+            if fnmatch.fnmatch(self.path, pat):
+                return True
+            if self.path.startswith(os.path.abspath(pat)):
+                return True
+        return False

--- a/inspektor/license.py
+++ b/inspektor/license.py
@@ -71,6 +71,8 @@ class LicenseChecker(object):
 
     def check_file(self, path):
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         # Don't put license info in empty __init__.py files.
         if not inspector.is_python() or inspector.is_empty():
             return True

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -69,6 +69,8 @@ class Linter(object):
                  find problems, or path is not a python module or script.
         """
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         if not inspector.is_python():
             return True
 

--- a/inspektor/reindent.py
+++ b/inspektor/reindent.py
@@ -204,6 +204,8 @@ class Reindenter(object):
                  script.
         """
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         if not inspector.is_python():
             return True
         f = open(path)

--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -63,6 +63,8 @@ class StyleChecker(object):
                  find problems, or path is not a python module or script.
         """
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         if not inspector.is_python():
             return True
         try:


### PR DESCRIPTION
Changes from V1 (PR #13 )
* Use ignore list from .gitignore (if available).
* Code refactory and rebase.

---

By default, ignore filenames that ends with ~, #, .swp, .pyc, .pyo, .o
since they are not the proper source code.

If the current directory has the .gitignore file or
$GIT_DIR/.config/gitignore or even $HOME/.config/git/ignore,
then this file (the first available) is read as a glob pattern and
used as the ignore list.

---
