### PR TITLE
Ignore filenames which are not the proper source code [V3]

### DIFF
--- a/inspektor/license.py
+++ b/inspektor/license.py
@@ -71,6 +71,8 @@ class LicenseChecker(object):
 
     def check_file(self, path):
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         # Don't put license info in empty __init__.py files.
         if not inspector.is_python() or inspector.is_empty():
             return True

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -69,6 +69,8 @@ class Linter(object):
                  find problems, or path is not a python module or script.
         """
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         if not inspector.is_python():
             return True
 

--- a/inspektor/reindent.py
+++ b/inspektor/reindent.py
@@ -204,6 +204,8 @@ class Reindenter(object):
                  script.
         """
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         if not inspector.is_python():
             return True
         f = open(path)

--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -63,6 +63,8 @@ class StyleChecker(object):
                  find problems, or path is not a python module or script.
         """
         inspector = PathInspector(path)
+        if inspector.is_toignore():
+            return True
         if not inspector.is_python():
             return True
         try:


### PR DESCRIPTION
Changes from V2 (PR #14):

* Extend the ignore list when reading the gitignore file.
* Forget duplicate entries in the ignore list, after reading files.

---

By default, ignore filenames that ends with ~, #, .swp, .pyc, .pyo, .o
since they are not the proper source code.

If the current directory has the .gitignore file or
$GIT_DIR/.config/gitignore or even $HOME/.config/git/ignore,
then this file (the first available) is read as a glob pattern and
extend the ignore list.

Note that, when performing the walking on files, the ignore list
is used to find directories to ignore (say build/).