### PR TITLE
Fix: inspekt lint failure when passed invalid path

### DIFF
--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -134,7 +134,9 @@ def run_lint(args):
 
     status = True
     for path in paths:
-        status &= linter.check(path)
+        lint_path = linter.check(path)
+        if not lint_path:
+            status = False
     if status:
         log.info("Syntax check PASS")
         return 0


### PR DESCRIPTION
Description:
When inspekt lint fired with invalid path it hits type error.
As linter.check() return None, comparison between bool and None occurs.

Repro step:
Try, 
inspekt lint random_string