### PR TITLE
inspektor: Handle incorrect locations

### DIFF
--- a/inspektor/license.py
+++ b/inspektor/license.py
@@ -111,6 +111,9 @@ class LicenseChecker(object):
             return self.check_file(path)
         elif os.path.isdir(path):
             return self.check_dir(path)
+        else:
+            log.warning("Invalid location '%s'", path)
+            return False
 
 
 def set_arguments(parser):

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -106,6 +106,9 @@ class Linter(object):
             return self.check_file(path)
         elif os.path.isdir(path):
             return self.check_dir(path)
+        else:
+            log.error("Invalid location '%s'", path)
+            return False
 
 
 def set_arguments(parser):

--- a/inspektor/reindent.py
+++ b/inspektor/reindent.py
@@ -243,6 +243,9 @@ class Reindenter(object):
             return self.check_file(path)
         elif os.path.isdir(path):
             return self.check_dir(path)
+        else:
+            log.warning("Invalid location '%s'", path)
+            return False
 
 
 def set_arguments(parser):

--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -110,6 +110,9 @@ class StyleChecker(object):
             return self.check_file(path)
         elif os.path.isdir(path):
             return self.check_dir(path)
+        else:
+            log.error("Invalid location '%s'", path)
+            return False
 
 
 def set_arguments(parser):


### PR DESCRIPTION
When checking incorrect location, the check() returns None without any
explanation. This patch logs an info and returns False as the check
failed.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>