### PR TITLE
Bug fix and code update for github pr check

### DIFF
--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -36,8 +36,8 @@ class Linter(object):
         sys.path.insert(0, os.getcwd())
         self.failed_paths = []
         if not self.verbose:
-            log.info('Pylint disabled: %s' % self.args.disable)
-            log.info('Pylint enabled : %s' % self.args.enable)
+            log.info('Pylint disabled: %s' % self.ignored_errors)
+            log.info('Pylint enabled : %s' % self.enabled_errors)
         else:
             log.info('Verbose mode, no disable/enable, full reports')
 
@@ -55,9 +55,9 @@ class Linter(object):
 
         if not self.verbose:
             if self.args.disable:
-                pylint_args.append('--disable=%s' % self.args.disable)
+                pylint_args.append('--disable=%s' % self.ignored_errors)
             if self.args.enable:
-                pylint_args.append('--enable=%s' % self.args.enable)
+                pylint_args.append('--enable=%s' % self.enabled_errors)
             pylint_args.append('--reports=no')
 
         return pylint_args

--- a/inspektor/utils/process.py
+++ b/inspektor/utils/process.py
@@ -51,14 +51,18 @@ class CmdResult(object):
                                    self.duration, self.stdout, self.stderr))
 
 
-def run(cmd, verbose=True, ignore_status=False):
+def run(cmd, verbose=True, ignore_status=False, shell=False):
     if verbose:
         log.info("Running '%s'", cmd)
-    args = shlex.split(cmd)
+    if shell is False:
+        args = shlex.split(cmd)
+    else:
+        args = cmd
     start = time.time()
     p = subprocess.Popen(args,
                          stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+                         stderr=subprocess.PIPE,
+                         shell=shell)
     stdout, stderr = p.communicate()
     duration = time.time() - start
     result = CmdResult(cmd)

--- a/inspektor/vcs.py
+++ b/inspektor/vcs.py
@@ -47,6 +47,12 @@ class VCS(object):
                            "must be at the top of the project's directory")
             return 1
 
+    def get_repo_name(self):
+        """
+        Get the repository name
+        """
+        return self.backend.get_repo_name()
+
     def get_unknown_files(self):
         """
         Return a list of files unknown to the VCS.
@@ -122,6 +128,12 @@ class SubVersionBackend(object):
         self.log = logging.getLogger('inspektor.vcs')
         self.name = 'subversion'
         self.ignored_extension_list = ['.orig', '.bak']
+
+    def get_repo_name(self):
+        """
+        Get the repository name
+        """
+        raise NotImplementedError
 
     def get_unknown_files(self):
         result = process.run("svn status --ignore-externals", verbose=False)
@@ -266,6 +278,14 @@ class GitBackend(object):
         self.ignored_extension_list = ['.orig', '.bak']
         self.name = 'git'
         self.log = logging.getLogger("inspektor.vcs")
+
+    def get_repo_name(self):
+        """
+        Get tje repository name from git remote command output.
+        """
+        cmd = "git remote -v | head -n1 | awk '{print $2}'"
+        cmd += " | sed -e 's,.*:\(.*/\)\?,,' -e 's/\.git$//'"
+        return process.run(cmd, verbose=False, shell=True).stdout.strip()
 
     def get_unknown_files(self):
         result = process.run("git status --porcelain", verbose=False)


### PR DESCRIPTION
1. github: Fix missing argument bug for github pull request checker
    Now classes Linter, Reindenter, StyleChecker and PathInspector all have
    the 'args' argument to pass cli arguments, but it's missed when do github
    pull request. And by fix this issue, it's also need add corresponding
    arguments for subcommand 'github'.
2. process.run: Allow run shell command in subprocess
3. Update getting parent project and repo name method
    By adding a '--parent-project' argument, now inspektor can check github
    pull request beyond 'autotest'. And as not all repos using the same
    style to write LICENSE, so change the way to get repo name.
    
