### PR TITLE
inspektor: Revert the default disabled checks

### DIFF
--- a/inspektor/check.py
+++ b/inspektor/check.py
@@ -245,7 +245,7 @@ def set_arguments(parser):
                      default='autotest')
     pgh.add_argument('--disable', type=str,
                      help='Disable the pylint errors. Default: %(default)s',
-                     default='C,E,R,W,F0401,I0011')
+                     default='W,R,C,E1002,E1101,E1103,E1120,F0401,I0011')
     pgh.add_argument('--enable', type=str,
                      help=('Enable the pylint errors '
                            '(takes place after disabled items are '

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -119,7 +119,7 @@ def set_arguments(parser):
                        default=None)
     plint.add_argument('--disable', type=str,
                        help='Disable the pylint errors. Default: %(default)s',
-                       default='C,E,R,W,F0401,I0011')
+                       default='W,R,C,E1002,E1101,E1103,E1120,F0401,I0011')
     plint.add_argument('--enable', type=str,
                        help=('Enable the pylint errors '
                              '(takes place after disabled items are '


### PR DESCRIPTION
The default disabled errors used to be:

    W,R,C,E1002,E1101,E1103,E1120,F0401,I0011

but when the `--disable` option was introduced it was changed to:

    C,E,R,W,F0401,I0011

I'd be fine with most of it, but the `E` is IMO not really good default
because wast majority of people are interested in Errors. This patch
reverts to the original defaults, which might uncover a lot of errors in
the projects depending on avocado as this default had lived with us for
more than a year. (checked on avocado, which fails)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>